### PR TITLE
[FEATURE] Stage 23. Empty RDB transfer on PSYNC

### DIFF
--- a/src/main/java/protocol/RespProtocol.java
+++ b/src/main/java/protocol/RespProtocol.java
@@ -12,6 +12,18 @@ public class RespProtocol {
     
     public static final String PONG_RESPONSE = "+PONG\r\n";
     public static final String OK_RESPONSE = "+OK\r\n";
+    private static final String EMPTY_RDB_HEX = "524544495330303131FE00FF6BFD95240E87F293";
+    public static final byte[] EMPTY_RDB_BYTES = hexStringToByteArray(EMPTY_RDB_HEX);
+
+    private static byte[] hexStringToByteArray(String s) {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                + Character.digit(s.charAt(i + 1), 16));
+        }
+        return data;
+    }
     
     /**
      * RESP 배열 형식을 파싱합니다.

--- a/src/main/java/server/RedisServer.java
+++ b/src/main/java/server/RedisServer.java
@@ -109,6 +109,17 @@ public class RedisServer {
                             String response = commandProcessor.processCommand(command, commands);
                             sendResponse(outputStream, response);
                             System.out.println("Sent: " + response.trim());
+                            
+                            // PSYNC에 대한 특별 처리: RDB 파일 전송
+                            if (command.equals("PSYNC") && response.startsWith("+FULLRESYNC")) {
+                                byte[] rdbFileBytes = RespProtocol.EMPTY_RDB_BYTES;
+                                String rdbFilePrefix = "$" + rdbFileBytes.length + "\r\n";
+                                
+                                outputStream.write(rdbFilePrefix.getBytes());
+                                outputStream.write(rdbFileBytes);
+                                outputStream.flush();
+                                System.out.println("Sent empty RDB file.");
+                            }
                         }
                     } else if (line.equals("PING")) {
                         // 단순 텍스트 PING 처리 (이전 호환성)


### PR DESCRIPTION
📌 개요
- **Issue**: #27
- 이 PR은 Redis 복제 과정의 Stage 23을 구현합니다.
- 마스터 서버가 레플리카로부터 `PSYNC` 명령을 수신했을 때, `FULLRESYNC` 응답과 함께 비어있는 RDB 파일을 전송하는 기능을 추가합니다.

🎯 변경사항
- **`RedisServer.java`**: 클라이언트 핸들러가 `PSYNC` 명령을 특별 처리하도록 수정했습니다. `FULLRESYNC` 응답을 보낸 후, 소켓 출력 스트림에 직접 RDB 파일의 바이너리 데이터를 기록하여 전송합니다.
- **`RespProtocol.java`**: 비어있는 RDB 파일의 16진수 값과 이를 바이트 배열로 변환하는 유틸리티 코드를 추가했습니다.
- **`CommandProcessor.java`**: 기존 `handlePsyncCommand`는 `FULLRESYNC` 문자열 응답만 생성하도록 유지하고, 실제 파일 전송 로직은 `RedisServer`로 이전하여 역할 분리를 명확히 했습니다.

✅ 구현 세부사항
- **문제점**: 처음에는 `CommandProcessor`가 응답 문자열과 RDB 파일 내용을 합쳐서 반환하도록 구현했으나, 이 과정에서 바이너리 데이터가 손상되어 CodeCrafters 테스트에 실패했습니다.
- **해결책**: `RedisServer`의 `handleClient` 메서드에서 직접 소켓의 `OutputStream`에 `FULLRESYNC` 응답과 RDB 파일 바이트를 순차적으로 쓰도록 변경하여, 데이터 손상 없이 전송 문제를 해결했습니다.

🧪 테스트 결과
- CodeCrafters 플랫폼에서 Stage 23을 포함한 모든 이전 단계의 테스트를 성공적으로 통과했습니다.
- 로그를 통해 `FULLRESYNC` 응답 후 RDB 파일이 정상적으로 수신되었음을 확인했습니다.

📝 추가 정보
- 이 구현은 향후 실제 RDB 파일 내용을 전송하는 기능으로 확장될 수 있는 기반을 마련합니다.


Closes #27 