### PR TITLE
[FEATURE] Stage 25. Multi-replica propagation

### DIFF
--- a/src/main/java/command/CommandProcessor.java
+++ b/src/main/java/command/CommandProcessor.java
@@ -5,6 +5,7 @@ import protocol.RespProtocol;
 import storage.StorageManager;
 import streams.StreamsManager;
 
+import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -17,11 +18,13 @@ public class CommandProcessor {
     private final ServerConfig config;
     private final StorageManager storageManager;
     private final StreamsManager streamsManager;
+    private final List<OutputStream> replicas;
     
-    public CommandProcessor(ServerConfig config, StorageManager storageManager, StreamsManager streamsManager) {
+    public CommandProcessor(ServerConfig config, StorageManager storageManager, StreamsManager streamsManager, List<OutputStream> replicas) {
         this.config = config;
         this.storageManager = storageManager;
         this.streamsManager = streamsManager;
+        this.replicas = replicas;
     }
     
     /**
@@ -201,7 +204,7 @@ public class CommandProcessor {
             replicationInfo.append("slave_read_only:1\r\n");
         } else {
             replicationInfo.append("role:master\r\n");
-            replicationInfo.append("connected_slaves:0\r\n");
+            replicationInfo.append("connected_slaves:").append(replicas.size()).append("\r\n");
             replicationInfo.append("master_replid:8371b4fb1155b71f4a04d3e1bc3e18c4a990aeeb\r\n");
             replicationInfo.append("master_repl_offset:0\r\n");
             replicationInfo.append("second_repl_offset:-1\r\n");

--- a/src/main/java/server/RedisServer.java
+++ b/src/main/java/server/RedisServer.java
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -36,7 +37,7 @@ public class RedisServer {
         this.config = config;
         this.storageManager = new StorageManager();
         this.streamsManager = new StreamsManager();
-        this.commandProcessor = new CommandProcessor(config, storageManager, streamsManager);
+        this.commandProcessor = new CommandProcessor(config, storageManager, streamsManager, this.replicas);
         this.rdbLoader = new RdbLoader(config, storageManager);
         this.replicationClient = new ReplicationClient(config);
     }
@@ -128,7 +129,8 @@ public class RedisServer {
                             }
                             
                             // 쓰기 명령어를 레플리카에 전파
-                            if (command.equals("SET")) {
+                            List<String> writeCommands = Arrays.asList("SET", "XADD", "INCR");
+                            if (writeCommands.contains(command)) {
                                 propagateCommand(commands);
                             }
                         }


### PR DESCRIPTION
📌 개요
- Redis Replication 기능의 Stage 25, 다중 레플리카에 대한 명령어 전파 기능을 구현합니다.
- 마스터 서버가 여러 레플리카의 연결을 동시에 관리하고, 쓰기 명령어를 모든 레플리카에 일괄적으로 전파하는 기능을 추가합니다.

🎯 변경사항
- `CommandProcessor`가 연결된 레플리카의 수를 동적으로 파악하여 `INFO` 명령어 실행 시 정확한 `connected_slaves` 수를 응답하도록 수정했습니다.
- `RedisServer`의 명령어 전파 로직을 리팩토링하여, `SET` 명령어뿐만 아니라 `XADD`, `INCR` 등 다른 주요 쓰기 명령어들도 모든 레플리카에 전파되도록 확장했습니다.
- `RedisServer` 생성자 로직을 수정하여 `final` 필드 재할당으로 인한 린터 오류를 해결했습니다.

✅ 구현 세부사항
- **`CommandProcessor.java`**
  - 생성자를 통해 `List<OutputStream> replicas`를 주입받도록 수정했습니다.
  - `buildReplicationInfo()` 메서드에서 `replicas.size()`를 사용하여 `connected_slaves` 필드의 값을 동적으로 설정합니다.
- **`RedisServer.java`**
  - `CommandProcessor` 인스턴스 생성 시 `replicas` 리스트를 전달하도록 생성자 호출 코드를 수정했습니다.
  - `handleClient()` 메서드 내 명령어 전파 조건을 `if (command.equals("SET"))`에서 `if (writeCommands.contains(command))`로 변경하여 여러 쓰기 명령어를 지원하도록 개선했습니다. (`writeCommands` = `SET`, `XADD`, `INCR`)

🧪 테스트 결과
- CodeCrafters의 Stage 25 테스트를 성공적으로 통과했습니다.
- 테스트 로그를 통해 여러 레플리카가 마스터에 접속하고, 마스터에서 발생한 쓰기 명령어가 모든 레플리카에 정상적으로 전파되는 것을 확인했습니다.

📝 추가 정보
- 이 PR은 Redis 서버의 복제 기능 확장성의 기반을 마련합니다.

Closes #29