### PR TITLE
[FEATURE] Stage 27: ACKs with no commands

### DIFF
--- a/src/main/java/command/CommandProcessor.java
+++ b/src/main/java/command/CommandProcessor.java
@@ -228,7 +228,13 @@ public class CommandProcessor {
             return RespProtocol.createErrorResponse("wrong number of arguments for 'REPLCONF' command");
         }
         
-        // REPLCONF의 모든 subcommand에 대해 OK 응답
+        // Stage 27: master로부터 REPLCONF GETACK *를 받을 때 ACK 응답
+        if ("GETACK".equalsIgnoreCase(args.get(1))) {
+            // ACK 0 응답
+            return RespProtocol.createRespArray(new String[]{"REPLCONF", "ACK", "0"});
+        }
+        
+        // REPLCONF의 모든 subcommand에 대해 OK 응답 (기존 로직 유지)
         // listening-port, capa 등의 인수는 현재 단계에서는 무시
         return RespProtocol.OK_RESPONSE;
     }


### PR DESCRIPTION
📌 개요
- Stage 27: ACKs with no commands를 구현합니다.

🎯 변경사항
- 레플리카가 마스터로부터 `REPLCONF GETACK *` 명령을 수신했을 때, `REPLCONF ACK 0`으로 응답하는 기능을 추가했습니다.

✅ 구현 세부사항
- `CommandProcessor.java`의 `handleReplconfCommand` 메소드를 수정하여 `GETACK` 하위 명령어를 처리하도록 변경했습니다.
- `GETACK` 이외의 `REPLCONF` 명령어는 기존과 동일하게 `+OK`를 반환합니다.

🧪 테스트 결과
- CodeCrafters의 Stage 27 테스트를 통과했습니다.

📝 추가 정보
- 이 PR은 Stage 27의 요구사항을 충족시키기 위해 작성되었습니다.

Closes #31