### PR TITLE
[FEATURE] Stage 29: WAIT 명령어 초기 구현

### DIFF
--- a/src/main/java/command/CommandProcessor.java
+++ b/src/main/java/command/CommandProcessor.java
@@ -56,11 +56,18 @@ public class CommandProcessor {
                 return handleXRangeCommand(args);
             case "XREAD":
                 return handleXReadCommand(args);
+            case "WAIT":
+                return handleWaitCommand(args);
             default:
                 return RespProtocol.createErrorResponse("unknown command '" + command + "'");
         }
     }
-    
+
+    private String handleWaitCommand(List<String> args) {
+        // Stage 29: For now, with no replicas, WAIT should return 0 immediately.
+        return RespProtocol.createInteger(0);
+    }
+
     /**
      * PING 명령어 처리
      */


### PR DESCRIPTION
📌 개요

Stage 29 요구사항에 따라 Redis `WAIT` 명령어의 초기 기능을 구현합니다. 이 단계에서는 연결된 복제본이 없을 때의 동작에 중점을 둡니다.

🎯 변경사항

- `WAIT` 명령어를 처리하는 로직을 추가했습니다.
- `CommandProcessor`에 `handleWaitCommand` 메서드를 구현하여 `WAIT` 요청을 처리합니다.
- 현재는 연결된 복제본이 없으므로, `WAIT` 명령어 수신 시 즉시 정수 `0`을 반환합니다.

✅ 구현 세부사항

- `src/main/java/command/CommandProcessor.java`:
  - `processCommand` 메서드의 `switch` 문에 `WAIT` 케이스를 추가했습니다.
  - `handleWaitCommand` 메서드를 새로 추가하여, `RespProtocol.createInteger(0)`를 통해 `:0\r\n` 응답을 생성하도록 구현했습니다.

🧪 테스트 결과

- CodeCrafters의 Stage 29 테스트를 성공적으로 통과했습니다.
- `git push` 로그에서 모든 스테이지가 통과되었음을 확인했습니다.

📝 추가 정보

- 이 PR은 `WAIT` 명령어 기능의 첫 번째 단계입니다. 후속 스테이지에서 복제본이 있을 때의 대기 및 타임아웃 로직이 추가될 예정입니다.

Closes #33