### PR TITLE
[FEATURE] Stage 30: WAIT 명령어 구현 (레플리카 수 반환)

### DIFF
--- a/src/main/java/command/CommandProcessor.java
+++ b/src/main/java/command/CommandProcessor.java
@@ -64,8 +64,8 @@ public class CommandProcessor {
     }
 
     private String handleWaitCommand(List<String> args) {
-        // Stage 29: For now, with no replicas, WAIT should return 0 immediately.
-        return RespProtocol.createInteger(0);
+        // Stage 30: Return the number of connected replicas.
+        return RespProtocol.createInteger(replicas.size());
     }
 
     /**


### PR DESCRIPTION
📌 개요
- Stage 30 요구사항에 따라 `WAIT` 명령어를 구현합니다.
- 이 단계에서는 `WAIT` 명령어가 호출되었을 때, 실제 대기 시간 없이 현재 연결된 레플리카의 수를 즉시 반환합니다.

🎯 변경사항
- `CommandProcessor`의 `handleWaitCommand` 메서드 로직을 수정했습니다.
- 기존에 `0`을 반환하던 로직을, `replicas` 리스트의 크기(`replicas.size()`)를 반환하도록 변경했습니다.

✅ 구현 세부사항
- `server.RedisServer`에서 관리하는 레플리카 `OutputStream` 목록(`replicas`)이 `command.CommandProcessor`에 주입됩니다.
- `WAIT` 명령어 수신 시, `CommandProcessor`는 이 리스트의 크기를 조회하여 연결된 레플리카의 총 수를 파악합니다.
- `protocol.RespProtocol.createInteger()`를 사용하여 조회된 레플리카 수를 RESP 정수 형식으로 인코딩하여 응답합니다.

🧪 테스트 결과
- CodeCrafters의 Stage 30 테스트를 통과했습니다.
- `git push origin HEAD:master` 명령을 통해 테스트 통과를 확인했습니다.

Closes #34