### PR TITLE
[FEATURE] Stage 31. WAIT with multiple commands

### DIFF
--- a/.cursor/rules/github-pr-guide.mdc
+++ b/.cursor/rules/github-pr-guide.mdc
@@ -1,4 +1,4 @@
-제목:
+제목(한글)):
 [FEATURE] Stage XX.
 
 내용:

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,17 @@
             <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/protocol/RespProtocol.java
+++ b/src/main/java/protocol/RespProtocol.java
@@ -2,8 +2,14 @@ package protocol;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.PushbackInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.io.ByteArrayOutputStream;
+import org.apache.commons.io.input.TeeInputStream;
 
 /**
  * Redis RESP 프로토콜 파싱 및 응답 생성을 담당하는 클래스
@@ -13,16 +19,46 @@ public class RespProtocol {
     public static final String PONG_RESPONSE = "+PONG\r\n";
     public static final String OK_RESPONSE = "+OK\r\n";
     private static final String EMPTY_RDB_HEX = "524544495330303131FE00FF6BFD95240E87F293";
-    public static final byte[] EMPTY_RDB_BYTES = hexStringToByteArray(EMPTY_RDB_HEX);
+    public static final byte[] EMPTY_RDB_BYTES = hexStringToByteArray("524544495330303131fa0972656469732d76657205372e322e30fa0a72656469732d626974730140fa056374696d65c26d08bc65fa08757365642d6d656d02b0c0ff00fe00fb000000ff959a41639e7288f7");
 
-    private static byte[] hexStringToByteArray(String s) {
-        int len = s.length();
-        byte[] data = new byte[len / 2];
-        for (int i = 0; i < len; i += 2) {
-            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
-                + Character.digit(s.charAt(i + 1), 16));
+    /**
+     * RESP 프로토콜을 파싱하여 명령어와 바이트 수를 반환합니다.
+     * @return List<Object> - [List<String> commands, Integer byteCount]
+     */
+    public static List<Object> parseResp(InputStream in) throws IOException {
+        ByteArrayOutputStream commandBytes = new ByteArrayOutputStream();
+        InputStream tee = new TeeInputStream(in, commandBytes);
+        
+        String arrayHeader = readLine(tee);
+        if (arrayHeader == null || !arrayHeader.startsWith("*")) {
+            return null; // or throw exception
         }
-        return data;
+        
+        int arrayLength = Integer.parseInt(arrayHeader.substring(1).trim());
+        List<String> commands = new ArrayList<>();
+        
+        for (int i = 0; i < arrayLength; i++) {
+            String bulkHeader = readLine(tee);
+            if (bulkHeader == null || !bulkHeader.startsWith("$")) {
+                throw new IOException("Expected bulk string header");
+            }
+            int bulkLength = Integer.parseInt(bulkHeader.substring(1).trim());
+            
+            if (bulkLength == -1) {
+                commands.add(null);
+            } else {
+                byte[] bulkContent = new byte[bulkLength];
+                int bytesRead = tee.read(bulkContent, 0, bulkLength);
+                if (bytesRead != bulkLength) {
+                    throw new IOException("Mismatched bulk string length");
+                }
+                // CRLF consuming
+                readLine(tee);
+                commands.add(new String(bulkContent, StandardCharsets.UTF_8));
+            }
+        }
+        
+        return Arrays.asList(commands, commandBytes.size());
     }
     
     /**
@@ -87,9 +123,9 @@ public class RespProtocol {
     }
     
     /**
-     * 정수 응답을 RESP 형식으로 생성합니다.
+     * RESP 정수를 생성합니다.
      */
-    public static String createInteger(long value) {
+    public static String createInteger(int value) {
         return ":" + value + "\r\n";
     }
     
@@ -123,5 +159,39 @@ public class RespProtocol {
         }
         
         return sb.toString();
+    }
+    
+    /**
+     * 입력 스트림에서 한 줄을 읽습니다 (CRLF 포함).
+     */
+    private static String readLine(InputStream in) throws IOException {
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        int b;
+        while ((b = in.read()) != -1) {
+            bos.write(b);
+            if (b == '\r') {
+                int nextByte = in.read();
+                if (nextByte == -1) break;
+                bos.write(nextByte);
+                if (nextByte == '\n') {
+                    break;
+                }
+            }
+        }
+        if (bos.size() == 0) return null;
+        return bos.toString(StandardCharsets.UTF_8);
+    }
+    
+    /**
+     * 16진수 문자열을 바이트 배열로 변환합니다.
+     */
+    public static byte[] hexStringToByteArray(String s) {
+        int len = s.length();
+        byte[] data = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
+                + Character.digit(s.charAt(i + 1), 16));
+        }
+        return data;
     }
 } 

--- a/src/main/java/replication/ReplicaInfo.java
+++ b/src/main/java/replication/ReplicaInfo.java
@@ -1,0 +1,42 @@
+package replication;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * 연결된 레플리카의 상태 정보를 담는 데이터 클래스
+ */
+public class ReplicaInfo {
+    private final Socket socket;
+    private final OutputStream outputStream;
+    private final String address;
+    private final AtomicLong ackOffset = new AtomicLong(0);
+    
+    public ReplicaInfo(Socket socket) throws IOException {
+        this.socket = socket;
+        this.outputStream = socket.getOutputStream();
+        this.address = socket.getRemoteSocketAddress().toString();
+    }
+    
+    public Socket getSocket() {
+        return socket;
+    }
+    
+    public OutputStream getOutputStream() {
+        return outputStream;
+    }
+    
+    public String getAddress() {
+        return address;
+    }
+    
+    public long getAckOffset() {
+        return ackOffset.get();
+    }
+    
+    public void setAckOffset(long offset) {
+        this.ackOffset.set(offset);
+    }
+} 

--- a/src/main/java/replication/ReplicationManager.java
+++ b/src/main/java/replication/ReplicationManager.java
@@ -1,0 +1,163 @@
+package replication;
+
+import command.CommandProcessor;
+import config.ServerConfig;
+import protocol.RespProtocol;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Master-Replica 복제 관련 로직을 관리하는 클래스
+ */
+public class ReplicationManager {
+    
+    private final ServerConfig config;
+    private final List<ReplicaInfo> replicas = new CopyOnWriteArrayList<>();
+    private final AtomicLong masterReplOffset = new AtomicLong(0);
+    private final Object waitLock = new Object();
+    
+    public ReplicationManager(ServerConfig config) {
+        this.config = config;
+    }
+    
+    /**
+     * 새로운 레플리카를 등록합니다.
+     */
+    public void addReplica(Socket clientSocket) {
+        try {
+            replicas.add(new ReplicaInfo(clientSocket));
+            System.out.println("New replica registered. Total replicas: " + replicas.size());
+        } catch (IOException e) {
+            System.err.println("Failed to register new replica: " + e.getMessage());
+        }
+    }
+    
+    /**
+     * 연결된 모든 레플리카에게 명령어를 전파합니다.
+     */
+    public void propagateCommand(List<String> commandParts) {
+        if (replicas.isEmpty()) {
+            return;
+        }
+        
+        String respCommand = RespProtocol.createRespArray(commandParts.toArray(new String[0]));
+        byte[] commandBytes = respCommand.getBytes();
+        
+        System.out.println("Propagating to " + replicas.size() + " replicas: " + respCommand.trim());
+        
+        for (ReplicaInfo replica : replicas) {
+            try {
+                replica.getOutputStream().write(commandBytes);
+                replica.getOutputStream().flush();
+            } catch (IOException e) {
+                System.err.println("Failed to propagate command to replica " + replica.getAddress() + ": " + e.getMessage());
+                // 연결이 끊긴 레플리카 제거
+                replicas.remove(replica);
+            }
+        }
+        
+        // 마스터 복제 오프셋 증가
+        masterReplOffset.addAndGet(commandBytes.length);
+    }
+    
+    /**
+     * WAIT 명령어를 처리합니다.
+     * 지정된 수의 레플리카가 현재 오프셋까지 동기화될 때까지 대기합니다.
+     */
+    public int waitForReplicas(int numReplicas, long timeout) {
+        long targetOffset = masterReplOffset.get();
+        
+        if (targetOffset == 0 || numReplicas == 0) {
+            return replicas.size();
+        }
+        
+        // 즉시 조건을 만족하는 레플리카 수 확인
+        int syncedReplicas = countSyncedReplicas(targetOffset);
+        if (syncedReplicas >= numReplicas) {
+            return syncedReplicas;
+        }
+        
+        long startTime = System.currentTimeMillis();
+        long remainingTimeout = timeout;
+        
+        synchronized (waitLock) {
+            while (remainingTimeout > 0) {
+                try {
+                    // ACK 응답을 기다림
+                    requestAcksFromReplicas();
+                    waitLock.wait(remainingTimeout);
+                    
+                    syncedReplicas = countSyncedReplicas(targetOffset);
+                    if (syncedReplicas >= numReplicas) {
+                        break;
+                    }
+                    
+                    long elapsedTime = System.currentTimeMillis() - startTime;
+                    remainingTimeout = timeout - elapsedTime;
+                    
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    System.err.println("WAIT command interrupted.");
+                    break;
+                }
+            }
+        }
+        
+        return countSyncedReplicas(targetOffset);
+    }
+    
+    /**
+     * 모든 레플리카에게 ACK 응답을 요청합니다 (GETACK).
+     */
+    private void requestAcksFromReplicas() {
+        String getAckCommand = RespProtocol.createRespArray(new String[]{"REPLCONF", "GETACK", "*"});
+        for (ReplicaInfo replica : replicas) {
+            try {
+                replica.getOutputStream().write(getAckCommand.getBytes());
+                replica.getOutputStream().flush();
+            } catch (IOException e) {
+                System.err.println("Failed to send GETACK to replica " + replica.getAddress());
+                replicas.remove(replica);
+            }
+        }
+    }
+    
+    /**
+     * 레플리카로부터 ACK 응답을 처리합니다.
+     */
+    public void processAck(Socket replicaSocket, long offset) {
+        for (ReplicaInfo replica : replicas) {
+            if (replica.getSocket().equals(replicaSocket)) {
+                replica.setAckOffset(offset);
+                System.out.println("Received ACK from replica " + replica.getAddress() + ": " + offset);
+                break;
+            }
+        }
+        
+        synchronized (waitLock) {
+            waitLock.notifyAll();
+        }
+    }
+    
+    private int countSyncedReplicas(long targetOffset) {
+        return (int) replicas.stream()
+                .filter(r -> r.getAckOffset() >= targetOffset)
+                .count();
+    }
+    
+    public long getMasterReplOffset() {
+        return masterReplOffset.get();
+    }
+    
+    public int getReplicaCount() {
+        return replicas.size();
+    }
+} 


### PR DESCRIPTION
📌 개요
WAIT 명령어의 완전한 기능을 구현하여, 지정된 수의 레플리카가 동기화되거나 타임아웃이 발생할 때까지 대기하는 Redis의 복제 기능을 완성합니다.

🎯 변경사항
WAIT <numreplicas> <timeout> 명령어 기능 구현
복제 관련 로직을 중앙에서 관리하는 ReplicationManager 클래스 도입
마스터의 복제 오프셋(master_repl_offset)과 레플리카별 ACK 오프셋 추적 기능 추가
명령어 전파 및 레플리카 ACK 응답 처리 로직 리팩토링

✅ 구현 세부사항
ReplicationManager & ReplicaInfo 추가:
복제 상태(레플리카 목록, 오프셋)와 로직(전파, ACK 처리, WAIT 대기)을 캡슐화했습니다.
RedisServer 리팩토링:
ReplicationManager를 사용하여 복제 관련 책임을 위임했습니다.
클라이언트 핸들러에서 레플리카의 REPLCONF ACK 응답을 감지하고 ReplicationManager로 전달하여 오프셋을 갱신합니다.
CommandProcessor 수정:
handleWaitCommand가 ReplicationManager.waitForReplicas()를 호출하여 동기식 대기 로직을 수행하도록 변경했습니다.
INFO 명령어에서 정확한 master_repl_offset과 레플리카 수를 보고하도록 수정했습니다.
ReplicationClient 수정:
레플리카가 마스터로부터 REPLCONF GETACK * 명령을 받으면, 로컬에 저장된 실제 처리 바이트(processedBytesOffset)를 사용하여 REPLCONF ACK <offset>으로 응답하도록 수정했습니다.
RespProtocol 및 pom.xml:
명령어 파싱 시 바이트 수를 정확히 계산하기 위해 parseResp 헬퍼 메서드를 추가하고, 필요한 commons-io 의존성을 pom.xml에 추가했습니다.

🧪 테스트 결과
CodeCrafters의 Stage 31 테스트를 포함한 모든 스테이지 테스트를 성공적으로 통과했습니다.

Closes #35