### PR TITLE
[FEATURE] Stage 32: Implement TYPE command

### DIFF
--- a/src/main/java/command/CommandProcessor.java
+++ b/src/main/java/command/CommandProcessor.java
@@ -42,6 +42,8 @@ public class CommandProcessor {
                 return RespProtocol.OK_RESPONSE;
             case "GET":
                 return handleGetCommand(args);
+            case "TYPE":
+                return handleTypeCommand(args);
             case "CONFIG":
                 return handleConfigCommand(args);
             case "KEYS":
@@ -79,6 +81,23 @@ public class CommandProcessor {
         } catch (NumberFormatException e) {
             return RespProtocol.createErrorResponse("value is not an integer or out of range");
         }
+    }
+    
+    private String handleTypeCommand(List<String> args) {
+        if (args.size() < 2) {
+            return RespProtocol.createErrorResponse("wrong number of arguments for 'type' command");
+        }
+        String key = args.get(1);
+
+        if (streamsManager.exists(key)) {
+            return RespProtocol.createSimpleString("stream");
+        }
+
+        if (storageManager.exists(key)) {
+            return RespProtocol.createSimpleString("string");
+        }
+        
+        return RespProtocol.createSimpleString("none");
     }
 
     /**

--- a/src/main/java/streams/StreamsManager.java
+++ b/src/main/java/streams/StreamsManager.java
@@ -88,6 +88,10 @@ public class StreamsManager {
         
         return sb.toString();
     }
+
+    public boolean exists(String key) {
+        return streams.containsKey(key);
+    }
     
     /**
      * 엔트리 ID를 처리합니다 (자동 생성 포함)


### PR DESCRIPTION
📌 개요
- Stage 32: `TYPE` 명령어를 구현하여 키의 데이터 타입을 반환하는 기능을 추가합니다.
- 지원 타입: `string`, `stream`, `none`

🎯 변경사항
- `CommandProcessor`에 `TYPE` 명령어 처리 로직 추가
- `StreamsManager`에 `exists` 메서드 추가하여 스트림 존재 여부 확인 기능 캡슐화

✅ 구현 세부사항
- `handleTypeCommand` 메서드에서 `StreamsManager`와 `StorageManager`를 순차적으로 확인하여 키의 타입을 결정합니다.
  - 스트림 키인 경우 "stream" 반환
  - 일반 저장소에 키가 존재하는 경우 "string" 반환
  - 어느 쪽에도 존재하지 않으면 "none" 반환

🧪 테스트 결과
- CodeCrafters의 자동 테스트를 모두 통과했습니다.

📝 추가 정보
- 다음 Stage 33에서 `XADD` 명령어를 통해 stream 타입이 추가될 것을 대비하여 미리 `stream` 타입을 반환하도록 구현했습니다.

Closes #36