### PR TITLE
[FEATURE] Stage 37. XRANGE Command

### DIFF
--- a/src/main/java/command/CommandProcessor.java
+++ b/src/main/java/command/CommandProcessor.java
@@ -295,41 +295,32 @@ public class CommandProcessor {
         
         String streamKey = args.get(1);
         String entryId = args.get(2);
-        
-        // 필드-값 쌍 추출
         List<String> fieldValues = args.subList(3, args.size());
         
         return streamsManager.addEntry(streamKey, entryId, fieldValues);
     }
     
-    /**
-     * Redis Streams XRANGE 명령어를 처리합니다.
-     */
     private String handleXRangeCommand(List<String> args) {
         if (args.size() < 4) {
             return RespProtocol.createErrorResponse("wrong number of arguments for 'XRANGE' command");
         }
         
-        String streamKey = args.get(1);
+        String key = args.get(1);
         String start = args.get(2);
         String end = args.get(3);
         
-        return streamsManager.getRange(streamKey, start, end);
+        return streamsManager.getRange(key, start, end);
     }
     
     /**
      * Redis Streams XREAD 명령어를 처리합니다.
      */
     private String handleXReadCommand(List<String> args) {
-        if (args.size() < 4) {
-            return RespProtocol.createErrorResponse("wrong number of arguments for 'XREAD' command");
-        }
-        
-        // XREAD streams streamKey lastId
-        if (!"streams".equalsIgnoreCase(args.get(1))) {
+        if (args.size() < 4 || !"STREAMS".equalsIgnoreCase(args.get(1))) {
             return RespProtocol.createErrorResponse("wrong arguments for 'XREAD' command");
         }
         
+        // XREAD streams streamKey lastId
         String streamKey = args.get(2);
         String lastId = args.get(3);
         

--- a/src/main/java/streams/StreamEntryId.java
+++ b/src/main/java/streams/StreamEntryId.java
@@ -1,0 +1,67 @@
+package streams;
+
+import java.util.Objects;
+
+public class StreamEntryId implements Comparable<StreamEntryId> {
+    
+    private final long time;
+    private final long sequence;
+    
+    public StreamEntryId(long time, long sequence) {
+        this.time = time;
+        this.sequence = sequence;
+    }
+    
+    public static StreamEntryId fromString(String idStr) {
+        if (idStr == null) {
+            throw new IllegalArgumentException("ID string cannot be null");
+        }
+        
+        String[] parts = idStr.split("-");
+        if (parts.length < 1 || parts.length > 2) {
+            throw new IllegalArgumentException("Invalid ID format: " + idStr);
+        }
+        
+        try {
+            long time = Long.parseLong(parts[0]);
+            long sequence = (parts.length == 2) ? Long.parseLong(parts[1]) : 0;
+            return new StreamEntryId(time, sequence);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid number in ID: " + idStr, e);
+        }
+    }
+    
+    public long getTime() {
+        return time;
+    }
+    
+    public long getSequence() {
+        return sequence;
+    }
+    
+    @Override
+    public int compareTo(StreamEntryId other) {
+        if (this.time != other.time) {
+            return Long.compare(this.time, other.time);
+        }
+        return Long.compare(this.sequence, other.sequence);
+    }
+    
+    @Override
+    public String toString() {
+        return time + "-" + sequence;
+    }
+    
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        StreamEntryId that = (StreamEntryId) o;
+        return time == that.time && sequence == that.sequence;
+    }
+    
+    @Override
+    public int hashCode() {
+        return Objects.hash(time, sequence);
+    }
+} 

--- a/src/main/java/streams/StreamsManager.java
+++ b/src/main/java/streams/StreamsManager.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * Redis Streams 기능을 관리하는 클래스
@@ -17,15 +18,25 @@ public class StreamsManager {
     /**
      * 스트림에 엔트리를 추가합니다.
      */
-    public String addEntry(String streamKey, String entryId, List<String> fieldValues) {
+    public String addEntry(String streamKey, String entryIdStr, List<String> fieldValues) {
         if (fieldValues.size() % 2 != 0) {
             return RespProtocol.createErrorResponse("wrong number of arguments for 'XADD' command");
         }
         
         // 엔트리 ID 검증 및 처리
-        String finalEntryId = processEntryId(streamKey, entryId);
-        if (finalEntryId.startsWith("-ERR")) {
-            return finalEntryId;
+        StreamEntryId finalEntryId;
+        try {
+            finalEntryId = processEntryId(streamKey, entryIdStr);
+        } catch (IllegalArgumentException e) {
+            return RespProtocol.createErrorResponse(e.getMessage());
+        }
+        
+        if (finalEntryId == null) {
+            // processEntryId에서 에러 응답을 직접 생성하는 경우
+            if ("0-0".equals(entryIdStr)) {
+                return RespProtocol.createErrorResponse("The ID specified in XADD must be greater than 0-0");
+            }
+            return RespProtocol.createErrorResponse("The ID specified in XADD is equal or smaller than the target stream top item");
         }
         
         // 스트림 엔트리 생성
@@ -34,46 +45,57 @@ public class StreamsManager {
         // 스트림에 추가
         streams.computeIfAbsent(streamKey, k -> new ArrayList<>()).add(entry);
         
-        System.out.println("Added stream entry: " + streamKey + " " + finalEntryId);
-        return RespProtocol.createBulkString(finalEntryId);
+        return RespProtocol.createBulkString(finalEntryId.toString());
     }
     
     /**
      * 스트림에서 범위 조회를 수행합니다.
      */
-    public String getRange(String streamKey, String start, String end) {
+    public String getRange(String streamKey, String startStr, String endStr) {
         List<StreamEntry> streamEntries = streams.get(streamKey);
         if (streamEntries == null || streamEntries.isEmpty()) {
             return RespProtocol.createEmptyArray();
         }
         
-        List<StreamEntry> result = new ArrayList<>();
+        StreamEntryId startId = parseRangeId(startStr, true);
+        StreamEntryId endId = parseRangeId(endStr, false);
         
-        for (StreamEntry entry : streamEntries) {
-            if (isInRange(entry.getId(), start, end)) {
-                result.add(entry);
-            }
-        }
+        List<StreamEntry> result = streamEntries.stream()
+                .filter(entry -> isInRange(entry.getId(), startId, endId))
+                .collect(Collectors.toList());
         
         return formatStreamEntries(result);
+    }
+    
+    private StreamEntryId parseRangeId(String idStr, boolean isStart) {
+        if ("-".equals(idStr)) return new StreamEntryId(0, 0);
+        if ("+".equals(idStr)) return new StreamEntryId(Long.MAX_VALUE, Long.MAX_VALUE);
+        
+        String[] parts = idStr.split("-");
+        long time = Long.parseLong(parts[0]);
+        long sequence;
+        if (parts.length == 2) {
+            sequence = Long.parseLong(parts[1]);
+        } else {
+            sequence = isStart ? 0 : Long.MAX_VALUE;
+        }
+        return new StreamEntryId(time, sequence);
     }
     
     /**
      * 스트림에서 특정 ID 이후의 엔트리들을 읽어옵니다.
      */
-    public String readStream(String streamKey, String lastId) {
+    public String readStream(String streamKey, String lastIdStr) {
         List<StreamEntry> streamEntries = streams.get(streamKey);
         if (streamEntries == null || streamEntries.isEmpty()) {
             return RespProtocol.createEmptyArray();
         }
         
-        List<StreamEntry> result = new ArrayList<>();
+        StreamEntryId lastId = StreamEntryId.fromString(lastIdStr);
         
-        for (StreamEntry entry : streamEntries) {
-            if (compareIds(entry.getId(), lastId) > 0) {
-                result.add(entry);
-            }
-        }
+        List<StreamEntry> result = streamEntries.stream()
+                .filter(entry -> entry.getId().compareTo(lastId) > 0)
+                .collect(Collectors.toList());
         
         if (result.isEmpty()) {
             return RespProtocol.createEmptyArray();
@@ -92,68 +114,57 @@ public class StreamsManager {
     /**
      * 엔트리 ID를 처리합니다 (자동 생성 포함)
      */
-    private String processEntryId(String streamKey, String entryId) {
-        if ("*".equals(entryId)) {
-            // 자동 ID 생성
+    private StreamEntryId processEntryId(String streamKey, String entryIdStr) {
+        if ("*".equals(entryIdStr)) {
             long currentTime = System.currentTimeMillis();
-            return currentTime + "-0";
+            List<StreamEntry> streamEntries = streams.get(streamKey);
+            if (streamEntries != null && !streamEntries.isEmpty()) {
+                StreamEntryId lastId = streamEntries.get(streamEntries.size() - 1).getId();
+                if (lastId.getTime() == currentTime) {
+                    return new StreamEntryId(currentTime, lastId.getSequence() + 1);
+                }
+            }
+            return new StreamEntryId(currentTime, 0);
         }
         
-        if (entryId.endsWith("-*")) {
-            // 시간은 주어지고 시퀀스는 자동 생성
-            String timeStr = entryId.substring(0, entryId.length() - 2);
-            return timeStr + "-0";
+        if (entryIdStr.endsWith("-*")) {
+            long time = Long.parseLong(entryIdStr.substring(0, entryIdStr.length() - 2));
+            List<StreamEntry> streamEntries = streams.get(streamKey);
+            long sequence = 0;
+            if (streamEntries != null && !streamEntries.isEmpty()) {
+                StreamEntryId lastId = streamEntries.get(streamEntries.size() - 1).getId();
+                if (lastId.getTime() == time) {
+                    sequence = lastId.getSequence() + 1;
+                }
+            }
+            if (time == 0 && sequence == 0) {
+                sequence = 1;
+            }
+            return new StreamEntryId(time, sequence);
         }
         
-        // ID 검증
-        if ("0-0".equals(entryId)) {
-            return RespProtocol.createErrorResponse("The ID specified in XADD must be greater than 0-0");
+        StreamEntryId currentId = StreamEntryId.fromString(entryIdStr);
+        
+        if (currentId.getTime() == 0 && currentId.getSequence() == 0) {
+            throw new IllegalArgumentException("The ID specified in XADD must be greater than 0-0");
         }
         
-        // 기존 엔트리와 비교
         List<StreamEntry> streamEntries = streams.get(streamKey);
         if (streamEntries != null && !streamEntries.isEmpty()) {
-            StreamEntry lastEntry = streamEntries.get(streamEntries.size() - 1);
-            if (compareIds(entryId, lastEntry.getId()) <= 0) {
-                return RespProtocol.createErrorResponse("The ID specified in XADD is equal or smaller than the target stream top item");
+            StreamEntryId lastId = streamEntries.get(streamEntries.size() - 1).getId();
+            if (currentId.compareTo(lastId) <= 0) {
+                throw new IllegalArgumentException("The ID specified in XADD is equal or smaller than the target stream top item");
             }
         }
         
-        return entryId;
+        return currentId;
     }
     
     /**
      * ID가 범위 내에 있는지 확인합니다
      */
-    private boolean isInRange(String id, String start, String end) {
-        if ("-".equals(start)) {
-            start = "0-0";
-        }
-        if ("+".equals(end)) {
-            return compareIds(id, start) >= 0;
-        }
-        
-        return compareIds(id, start) >= 0 && compareIds(id, end) <= 0;
-    }
-    
-    /**
-     * 두 엔트리 ID를 비교합니다
-     */
-    private int compareIds(String id1, String id2) {
-        String[] parts1 = id1.split("-");
-        String[] parts2 = id2.split("-");
-        
-        long time1 = Long.parseLong(parts1[0]);
-        long time2 = Long.parseLong(parts2[0]);
-        
-        if (time1 != time2) {
-            return Long.compare(time1, time2);
-        }
-        
-        long seq1 = parts1.length > 1 ? Long.parseLong(parts1[1]) : 0;
-        long seq2 = parts2.length > 1 ? Long.parseLong(parts2[1]) : 0;
-        
-        return Long.compare(seq1, seq2);
+    private boolean isInRange(StreamEntryId id, StreamEntryId start, StreamEntryId end) {
+        return id.compareTo(start) >= 0 && id.compareTo(end) <= 0;
     }
     
     /**
@@ -165,7 +176,7 @@ public class StreamsManager {
         
         for (StreamEntry entry : entries) {
             sb.append("*2\r\n"); // [id, [field, value, ...]]
-            sb.append(RespProtocol.createBulkString(entry.getId()));
+            sb.append(RespProtocol.createBulkString(entry.getId().toString()));
             sb.append("*").append(entry.getFieldValues().size()).append("\r\n");
             for (String fieldValue : entry.getFieldValues()) {
                 sb.append(RespProtocol.createBulkString(fieldValue));
@@ -179,17 +190,15 @@ public class StreamsManager {
      * Redis Streams 엔트리를 저장하는 내부 클래스
      */
     public static class StreamEntry {
-        private final String id;
+        private final StreamEntryId id;
         private final List<String> fieldValues;
         
-        // 커스텀 생성자 - fieldValues를 새로운 ArrayList로 복사
-        public StreamEntry(String id, List<String> fieldValues) {
+        public StreamEntry(StreamEntryId id, List<String> fieldValues) {
             this.id = id;
             this.fieldValues = new ArrayList<>(fieldValues);
         }
         
-        // Getter 메서드들
-        public String getId() {
+        public StreamEntryId getId() {
             return id;
         }
         


### PR DESCRIPTION
📌 개요
- Redis Streams의 XRANGE 명령어를 구현하여 지정된 ID 범위 내의 스트림 엔트리를 조회하는 기능을 추가합니다.

🎯 변경사항
- `XRANGE key start end` 명령어 처리 로직 추가
- 스트림 ID(`<ms>-<seq>`) 파싱 및 비교를 위한 `StreamEntryId` 클래스 도입
- `StreamsManager`를 리팩토링하여 `StreamEntryId`를 사용하고, 범위 검색 로직을 개선

✅ 구현 세부사항
1. **`StreamEntryId.java` 추가**
   - 스트림 엔트리 ID를 객체로 다루어 파싱, 비교, 유효성 검증 로직을 캡슐화했습니다.
   - `Comparable` 인터페이스를 구현하여 ID 간의 정렬 및 비교가 용이하도록 했습니다.
2. **`StreamsManager.java` 리팩토링**
   - `String` 타입으로 다루던 ID를 `StreamEntryId` 객체로 변경하여 타입 안정성을 높였습니다.
   - `getRange` 메서드에서 `start`, `end` 인자에 대해 시퀀스 번호가 생략된 경우를 포함한 다양한 ID 형식을 처리하도록 `parseRangeId` 헬퍼 메서드를 구현했습니다.
   - `isInRange` 로직을 `StreamEntryId.compareTo()`를 사용하도록 단순화했습니다.
3. **`CommandProcessor.java` 수정**
   - `handleXRangeCommand` 메서드를 구현하여 `XRANGE` 명령어를 `StreamsManager.getRange`에 연결했습니다.

🧪 테스트 결과
- CodeCrafters의 Stage 37 테스트를 포함한 모든 스테이지 테스트를 통과했습니다.

📝 추가 정보
- 이번 변경을 통해 스트림 관련 코드의 안정성과 확장성이 향상되었습니다.

Closes #41