### PR TITLE
[FEATURE] Stage 38. XRANGE에서 '-' 인자 지원

### DIFF
--- a/src/main/java/command/CommandProcessor.java
+++ b/src/main/java/command/CommandProcessor.java
@@ -329,7 +329,7 @@ public class CommandProcessor {
         String start = args.get(2);
         String end = args.get(3);
         
-        return streamsManager.getRange(key, start, end);
+        return streamsManager.xrange(key, start, end);
     }
     
     /**

--- a/src/main/java/streams/StreamsManager.java
+++ b/src/main/java/streams/StreamsManager.java
@@ -14,24 +14,37 @@ import java.util.stream.Collectors;
 public class StreamsManager {
     
     private final Map<String, List<StreamEntry>> streams = new ConcurrentHashMap<>();
-
+    
     /**
      * Represents a stream entry ID.
      */
     public record StreamId(long time, long sequence) implements Comparable<StreamId> {
         public static StreamId fromString(String idStr) {
-            if (idStr == null || !idStr.contains("-")) {
-                throw new IllegalArgumentException("Invalid stream ID format");
+            if (idStr == null) {
+                throw new IllegalArgumentException("Invalid stream ID format: null");
             }
+            if ("-".equals(idStr)) {
+                return new StreamId(0, 0);
+            }
+            if ("+".equals(idStr)) {
+                return new StreamId(Long.MAX_VALUE, Long.MAX_VALUE);
+            }
+            
             String[] parts = idStr.split("-");
-            return new StreamId(Long.parseLong(parts[0]), Long.parseLong(parts[1]));
+            if (parts.length == 1) {
+                return new StreamId(Long.parseLong(parts[0]), 0);
+            }
+            if (parts.length == 2) {
+                return new StreamId(Long.parseLong(parts[0]), Long.parseLong(parts[1]));
+            }
+            throw new IllegalArgumentException("Invalid stream ID format: " + idStr);
         }
-
+        
         @Override
         public String toString() {
             return time + "-" + sequence;
         }
-
+        
         @Override
         public int compareTo(StreamId other) {
             if (this.time != other.time) {
@@ -42,33 +55,43 @@ public class StreamsManager {
     }
     
     /**
+     * Redis Streams 엔트리를 저장하는 내부 클래스
+     */
+    public static class StreamEntry {
+        private final StreamId id;
+        private final List<String> fieldValues;
+        
+        public StreamEntry(StreamId id, List<String> fieldValues) {
+            this.id = id;
+            this.fieldValues = fieldValues;
+        }
+        
+        public StreamId getId() {
+            return id;
+        }
+        
+        public List<String> getFieldValues() {
+            return fieldValues;
+        }
+    }
+    
+    /**
      * 스트림에 엔트리를 추가합니다.
      */
     public String addEntry(String streamKey, String entryIdStr, List<String> fieldValues) {
         if (fieldValues.size() % 2 != 0) {
             return RespProtocol.createErrorResponse("wrong number of arguments for 'XADD' command");
         }
-
-        // 엔트리 ID 검증 및 처리
-        StreamEntryId finalEntryId;
+        
+        StreamId finalEntryId;
         try {
             finalEntryId = processEntryId(streamKey, entryIdStr);
         } catch (IllegalArgumentException e) {
             return RespProtocol.createErrorResponse(e.getMessage());
         }
         
-        if (finalEntryId == null) {
-            // processEntryId에서 에러 응답을 직접 생성하는 경우
-            if ("0-0".equals(entryIdStr)) {
-                return RespProtocol.createErrorResponse("The ID specified in XADD must be greater than 0-0");
-            }
-            return RespProtocol.createErrorResponse("The ID specified in XADD is equal or smaller than the target stream top item");
-        }
-        
-        // 스트림 엔트리 생성
         StreamEntry entry = new StreamEntry(finalEntryId, fieldValues);
         
-        // 스트림에 추가
         streams.computeIfAbsent(streamKey, k -> new ArrayList<>()).add(entry);
         
         return RespProtocol.createBulkString(finalEntryId.toString());
@@ -77,126 +100,24 @@ public class StreamsManager {
     /**
      * 스트림에서 범위 조회를 수행합니다.
      */
-    public String getRange(String streamKey, String startStr, String endStr) {
+    public String xrange(String streamKey, String startStr, String endStr) {
         List<StreamEntry> streamEntries = streams.get(streamKey);
         if (streamEntries == null || streamEntries.isEmpty()) {
             return RespProtocol.createEmptyArray();
         }
         
-        StreamEntryId startId = parseRangeId(startStr, true);
-        StreamEntryId endId = parseRangeId(endStr, false);
+        StreamId startId = parseRangeId(startStr, true);
+        StreamId endId = parseRangeId(endStr, false);
         
         List<StreamEntry> result = streamEntries.stream()
-                .filter(entry -> isInRange(entry.getId(), startId, endId))
-                .collect(Collectors.toList());
+                                                 .filter(entry -> isInRange(entry.getId(), startId, endId))
+                                                 .collect(Collectors.toList());
         
         return formatStreamEntries(result);
     }
     
-    private StreamEntryId parseRangeId(String idStr, boolean isStart) {
-        if ("-".equals(idStr)) return new StreamEntryId(0, 0);
-        if ("+".equals(idStr)) return new StreamEntryId(Long.MAX_VALUE, Long.MAX_VALUE);
-        
-        String[] parts = idStr.split("-");
-        long time = Long.parseLong(parts[0]);
-        long sequence;
-        if (parts.length == 2) {
-            sequence = Long.parseLong(parts[1]);
-        } else {
-            sequence = isStart ? 0 : Long.MAX_VALUE;
-        }
-        return new StreamEntryId(time, sequence);
-    }
-    
-    /**
-     * 스트림에서 특정 ID 이후의 엔트리들을 읽어옵니다.
-     */
-    public String readStream(String streamKey, String lastIdStr) {
-        List<StreamEntry> streamEntries = streams.get(streamKey);
-        if (streamEntries == null || streamEntries.isEmpty()) {
-            return RespProtocol.createEmptyArray();
-        }
-        
-        List<StreamEntry> result = new ArrayList<>();
-        StreamId lastStreamId = StreamId.fromString(lastId);
-
-        for (StreamEntry entry : streamEntries) {
-            if (StreamId.fromString(entry.getId()).compareTo(lastStreamId) > 0) {
-                result.add(entry);
-            }
-        }
-        
-        if (result.isEmpty()) {
-            return RespProtocol.createEmptyArray();
-        }
-        
-        // XREAD 형식: [streamKey, [entries]]
-        StringBuilder sb = new StringBuilder();
-        sb.append("*1\r\n"); // 1개 스트림
-        sb.append("*2\r\n"); // [streamKey, entries]
-        sb.append(RespProtocol.createBulkString(streamKey));
-        sb.append(formatStreamEntries(result));
-        
-        return sb.toString();
-    }
-
-    public boolean exists(String key) {
-        return streams.containsKey(key);
-    }
-    
-    /**
-     * 엔트리 ID를 처리합니다 (자동 생성 포함)
-     */
-
-    private StreamEntryId processEntryId(String streamKey, String entryIdStr) {
-        if ("*".equals(entryIdStr)) {
-            long currentTime = System.currentTimeMillis();
-            List<StreamEntry> streamEntries = streams.get(streamKey);
-            if (streamEntries != null && !streamEntries.isEmpty()) {
-                StreamEntryId lastId = streamEntries.get(streamEntries.size() - 1).getId();
-                if (lastId.getTime() == currentTime) {
-                    return new StreamEntryId(currentTime, lastId.getSequence() + 1);
-                }
-            }
-            return new StreamEntryId(currentTime, 0);
-        }
-        
-        if (entryIdStr.endsWith("-*")) {
-            long time = Long.parseLong(entryIdStr.substring(0, entryIdStr.length() - 2));
-            List<StreamEntry> streamEntries = streams.get(streamKey);
-            long sequence = 0;
-            if (streamEntries != null && !streamEntries.isEmpty()) {
-                StreamEntryId lastId = streamEntries.get(streamEntries.size() - 1).getId();
-                if (lastId.getTime() == time) {
-                    sequence = lastId.getSequence() + 1;
-                }
-            }
-            if (time == 0 && sequence == 0) {
-                sequence = 1;
-            }
-            return new StreamEntryId(time, sequence);
-        }
-        
-        StreamEntryId currentId = StreamEntryId.fromString(entryIdStr);
-        
-        if (currentId.getTime() == 0 && currentId.getSequence() == 0) {
-            throw new IllegalArgumentException("The ID specified in XADD must be greater than 0-0");
-        }
-        
-        List<StreamEntry> streamEntries = streams.get(streamKey);
-        if (streamEntries != null && !streamEntries.isEmpty()) {
-            StreamEntryId lastId = streamEntries.get(streamEntries.size() - 1).getId();
-            if (currentId.compareTo(lastId) <= 0) {
-                throw new IllegalArgumentException("The ID specified in XADD is equal or smaller than the target stream top item");
-            }
-
-
-    private boolean isInRange(String id, String start, String end) {
-        StreamId streamId = StreamId.fromString(id);
-        StreamId startId = parseRangeId(start, true);
-        StreamId endId = parseRangeId(end, false);
-        
-        return streamId.compareTo(startId) >= 0 && streamId.compareTo(endId) <= 0;
+    private boolean isInRange(StreamId id, StreamId startId, StreamId endId) {
+        return id.compareTo(startId) >= 0 && id.compareTo(endId) <= 0;
     }
     
     private StreamId parseRangeId(String idStr, boolean isStart) {
@@ -212,23 +133,99 @@ public class StreamsManager {
         }
         return StreamId.fromString(idStr);
     }
-
-    /**
-     * 두 엔트리 ID를 비교합니다
-     */
-    private int compareIds(String id1, String id2) {
-        return StreamId.fromString(id1).compareTo(StreamId.fromString(id2));
-    }
     
     /**
-     * 스트림 엔트리들을 RESP 형식으로 포맷합니다
+     * 스트림에서 특정 ID 이후의 엔트리들을 읽어옵니다.
      */
+    public String readStream(String streamKey, String lastIdStr) {
+        List<StreamEntry> streamEntries = streams.get(streamKey);
+        if (streamEntries == null || streamEntries.isEmpty()) {
+            return RespProtocol.createEmptyArray();
+        }
+        
+        StreamId lastStreamId;
+        if ("$".equals(lastIdStr)) {
+            if (streamEntries.isEmpty()) {
+                return RespProtocol.createEmptyArray();
+            }
+            lastStreamId = streamEntries.get(streamEntries.size() - 1).getId();
+        } else {
+            lastStreamId = StreamId.fromString(lastIdStr);
+        }
+        
+        List<StreamEntry> result = streamEntries.stream()
+                                                 .filter(entry -> entry.getId().compareTo(lastStreamId) > 0)
+                                                 .collect(Collectors.toList());
+        
+        if (result.isEmpty()) {
+            return RespProtocol.createEmptyArray();
+        }
+        
+        StringBuilder sb = new StringBuilder();
+        sb.append("*1\r\n");
+        sb.append("*2\r\n");
+        sb.append(RespProtocol.createBulkString(streamKey));
+        sb.append(formatStreamEntries(result));
+        
+        return sb.toString();
+    }
+    
+    public boolean exists(String key) {
+        return streams.containsKey(key);
+    }
+    
+    private StreamId processEntryId(String streamKey, String entryIdStr) {
+        if ("*".equals(entryIdStr)) {
+            long currentTime = System.currentTimeMillis();
+            List<StreamEntry> streamEntries = streams.get(streamKey);
+            if (streamEntries != null && !streamEntries.isEmpty()) {
+                StreamId lastId = streamEntries.get(streamEntries.size() - 1).getId();
+                if (lastId.time() == currentTime) {
+                    return new StreamId(currentTime, lastId.sequence() + 1);
+                }
+            }
+            return new StreamId(currentTime, 0);
+        }
+        
+        if (entryIdStr.endsWith("-*")) {
+            long time = Long.parseLong(entryIdStr.substring(0, entryIdStr.length() - 2));
+            List<StreamEntry> streamEntries = streams.get(streamKey);
+            long sequence = 0;
+            if (streamEntries != null && !streamEntries.isEmpty()) {
+                StreamId lastId = streamEntries.get(streamEntries.size() - 1).getId();
+                if (lastId.time() == time) {
+                    sequence = lastId.sequence() + 1;
+                }
+            }
+            if (time == 0 && sequence == 0) {
+                sequence = 1;
+            }
+            return new StreamId(time, sequence);
+        }
+        
+        StreamId currentId = StreamId.fromString(entryIdStr);
+        
+        if (currentId.time() == 0 && currentId.sequence() == 0) {
+            throw new IllegalArgumentException("The ID specified in XADD must be greater than 0-0");
+        }
+        
+        List<StreamEntry> streamEntries = streams.get(streamKey);
+        if (streamEntries != null && !streamEntries.isEmpty()) {
+            StreamId lastId = streamEntries.get(streamEntries.size() - 1).getId();
+            if (currentId.compareTo(lastId) <= 0) {
+                throw new IllegalArgumentException("The ID specified in XADD is equal or smaller than the target stream top item");
+            }
+        }
+        
+        return currentId;
+    }
+    
     private String formatStreamEntries(List<StreamEntry> entries) {
         StringBuilder sb = new StringBuilder();
         sb.append("*").append(entries.size()).append("\r\n");
         
         for (StreamEntry entry : entries) {
-            sb.append("*2\r\n"); // [id, [field, value, ...]]
+            sb.append("*2\r\n");
             sb.append(RespProtocol.createBulkString(entry.getId().toString()));
             sb.append("*").append(entry.getFieldValues().size()).append("\r\n");
             for (String fieldValue : entry.getFieldValues()) {
@@ -237,26 +234,5 @@ public class StreamsManager {
         }
         
         return sb.toString();
-    }
-    
-    /**
-     * Redis Streams 엔트리를 저장하는 내부 클래스
-     */
-    public static class StreamEntry {
-        private final StreamEntryId id;
-        private final List<String> fieldValues;
-        
-        public StreamEntry(StreamEntryId id, List<String> fieldValues) {
-            this.id = id;
-            this.fieldValues = new ArrayList<>(fieldValues);
-        }
-        
-        public StreamEntryId getId() {
-            return id;
-        }
-        
-        public List<String> getFieldValues() {
-            return fieldValues;
-        }
     }
 } 


### PR DESCRIPTION
📌 개요

Redis Streams의 `XRANGE` 명령어에서 시작점으로 `-`를 사용할 수 있도록 기능을 확장합니다. 이를 통해 스트림의 처음부터 특정 지점까지의 모든 항목을 조회할 수 있습니다.

🎯 변경사항

*   `StreamsManager` 클래스를 리팩토링하여 `StreamId`와 `StreamEntry` 관련 로직을 개선하고 중복 코드를 제거했습니다.
*   `CommandProcessor`에서 `streamsManager.xrange`를 호출하도록 수정했습니다.
*   `StreamsManager`의 `xrange` 메서드에서 `-`를 시작점으로 인식하여 `0-0`으로 처리하는 로직을 구현했습니다.

✅ 구현 세부사항

*   `StreamsManager.java`의 `parseRangeId` 메서드가 `-` 문자열을 `new StreamId(0, 0)`으로 변환합니다.
*   `isInRange` 메서드가 `compareTo`를 사용하여 올바른 범위 비교(>=, <=)를 수행합니다.
*   `StreamEntryId` 클래스를 `StreamId` 레코드로 통합하여 코드의 일관성과 가독성을 향상시켰습니다.

🧪 테스트 결과

*   CodeCrafters의 Stage 38 테스트를 성공적으로 통과했습니다.

📝 추가 정보

*   `StreamsManager.java` 파일에 대한 대대적인 리팩토링이 포함되어 있습니다.

Closes #42