### PR TITLE
[FEATURE] Stage 39: Query with +

### DIFF
--- a/src/main/java/streams/StreamsManager.java
+++ b/src/main/java/streams/StreamsManager.java
@@ -122,10 +122,10 @@ public class StreamsManager {
     
     private StreamId parseRangeId(String idStr, boolean isStart) {
         if ("-".equals(idStr)) {
-            return new StreamId(0, 0);
+            return new StreamId(0, 0); // Represents the minimum possible ID
         }
         if ("+".equals(idStr)) {
-            return new StreamId(Long.MAX_VALUE, Long.MAX_VALUE);
+            return new StreamId(Long.MAX_VALUE, Long.MAX_VALUE); // Represents the maximum possible ID
         }
         if (!idStr.contains("-")) {
             long time = Long.parseLong(idStr);


### PR DESCRIPTION
## [FEATURE] Stage 39: Query with +

### 📌 개요
Redis Streams의 XRANGE 명령어에 `+`를 사용하여 스트림의 마지막까지 조회하는 기능을 구현합니다.

### 🎯 변경사항
- `StreamsManager.java`의 `parseRangeId` 메서드에 주석을 추가하여 `+` 기호 처리 로직을 명확히 했습니다.
- 기존에 기능이 이미 구현되어 있어, 코드 변경은 주석 추가에 한정됩니다.

### ✅ 구현 세부사항
`XRANGE`의 `end` 인자로 `+`가 들어올 경우, 이를 `Long.MAX_VALUE`로 변환하여 스트림의 모든 남은 엔트리가 범위에 포함되도록 합니다.

### 🧪 테스트 결과
CodeCrafters의 Stage 39 테스트를 통과하였습니다.

### 📝 추가 정보
-

Closes #43
