### PR TITLE
[FEATURE] Stage 41: Query multiple streams using XREAD

### DIFF
--- a/src/main/java/command/CommandProcessor.java
+++ b/src/main/java/command/CommandProcessor.java
@@ -337,30 +337,20 @@ public class CommandProcessor {
      */
     private String handleXReadCommand(List<String> args) {
         if (args.size() < 4 || !"streams".equalsIgnoreCase(args.get(1))) {
-            return RespProtocol.createErrorResponse("wrong number of arguments for 'XREAD' command or missing 'streams' keyword");
-        }
-
-        int streamKeywordIndex = -1;
-        for (int i = 0; i < args.size(); i++) {
-            if ("streams".equalsIgnoreCase(args.get(i))) {
-                streamKeywordIndex = i;
-                break;
-            }
-        }
-
-        if (streamKeywordIndex == -1) {
-            return RespProtocol.createErrorResponse("Syntax error in XREAD command");
+            return RespProtocol.createErrorResponse("ERR syntax error");
         }
         
-        List<String> streamKeysAndIds = args.subList(streamKeywordIndex + 1, args.size());
-        if (streamKeysAndIds.size() % 2 != 0) {
-            return RespProtocol.createErrorResponse("Unbalanced list of streams and IDs");
+        // streams 키워드 제외
+        List<String> allArgs = args.subList(2, args.size());
+        
+        int numStreams = allArgs.size() / 2;
+        if (allArgs.size() % 2 != 0) {
+            return RespProtocol.createErrorResponse("ERR Unbalanced XREAD list of streams: for each stream key an ID must be specified.");
         }
         
-        int numStreams = streamKeysAndIds.size() / 2;
-        List<String> streamKeys = streamKeysAndIds.subList(0, numStreams);
-        List<String> lastIds = streamKeysAndIds.subList(numStreams, streamKeysAndIds.size());
+        List<String> keys = new ArrayList<>(allArgs.subList(0, numStreams));
+        List<String> ids = new ArrayList<>(allArgs.subList(numStreams, allArgs.size()));
 
-        return streamsManager.readStreams(streamKeys, lastIds);
+        return streamsManager.readStreams(keys, ids);
     }
 } 


### PR DESCRIPTION
제목(한글)):
[FEATURE] Stage 41: XREAD 다중 스트림 쿼리

내용:
📌 개요
XREAD 명령어에서 여러 스트림을 동시에 쿼리하는 기능을 구현합니다.

🎯 변경사항
- `CommandProcessor`의 `handleXReadCommand` 메서드를 수정하여 여러 개의 스트림 키와 ID를 파싱할 수 있도록 변경했습니다.
- 파싱된 키와 ID를 `StreamsManager`의 `readStreams` 메서드로 전달하여 쿼리를 수행합니다.

✅ 구현 세부사항
- `handleXReadCommand`에서 `XREAD streams <key1> <key2> ... <id1> <id2> ...` 형식의 인자를 처리합니다.
- 인자의 유효성을 검사하고, 키 리스트와 ID 리스트를 분리합니다.
- `streamsManager.readStreams`는 각 스트림에 대해 ID 이후의 엔트리를 조회하고, 이를 RESP 형식에 맞는 중첩 배열로 반환합니다.

🧪 테스트 결과
CodeCrafters의 Stage 41 테스트를 통과했습니다.

📝 추가 정보
- Stage 41의 요구사항에 따라 기능 구현에 집중했습니다.

Closes #45