### PR TITLE
[FEATURE] Stage 48. MULTI 명령어

### DIFF
--- a/src/main/java/protocol/RespProtocol.java
+++ b/src/main/java/protocol/RespProtocol.java
@@ -21,6 +21,7 @@ public class RespProtocol {
     
     public static final String PONG_RESPONSE = "+PONG\r\n";
     public static final String OK_RESPONSE = "+OK\r\n";
+    public static final String QUEUED_RESPONSE = "+QUEUED\r\n";
     private static final String EMPTY_RDB_HEX = "524544495330303131FE00FF6BFD95240E87F293";
     public static final byte[] EMPTY_RDB_BYTES = hexStringToByteArray("524544495330303131fa0972656469732d76657205372e322e30fa0a72656469732d626974730140fa056374696d65c26d08bc65fa08757365642d6d656d02b0c0ff00fe00fb000000ff959a41639e7288f7");
 
@@ -112,6 +113,19 @@ public class RespProtocol {
             sb.append(createBulkString(element));
         }
         
+        return sb.toString();
+    }
+
+    /**
+     * Raw RESP 응답 목록으로 RESP 배열을 생성합니다.
+     * EXEC 명령어 응답 처리에 사용됩니다.
+     */
+    public static String createRespArrayFromRaw(List<String> rawResponses) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("*").append(rawResponses.size()).append("\r\n");
+        for (String response : rawResponses) {
+            sb.append(response);
+        }
         return sb.toString();
     }
     

--- a/src/main/java/server/RedisServer.java
+++ b/src/main/java/server/RedisServer.java
@@ -16,6 +16,7 @@ import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -94,6 +95,8 @@ public class RedisServer {
      */
     private void handleClient(Socket clientSocket) {
         String clientAddress = clientSocket.getRemoteSocketAddress().toString();
+        boolean inTransaction = false;
+        List<List<String>> transactionQueue = new ArrayList<>();
         
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
              OutputStream outputStream = clientSocket.getOutputStream()) {
@@ -109,37 +112,88 @@ public class RedisServer {
                         int arrayLength = Integer.parseInt(line.substring(1));
                         List<String> commands = RespProtocol.parseRespArray(reader, arrayLength);
                         
-                        if (!commands.isEmpty()) {
-                            String command = commands.get(0).toUpperCase();
-                            
-                            // 레플리카로부터의 ACK 처리
-                            if (command.equals("REPLCONF") && commands.size() >= 3 && "ACK".equalsIgnoreCase(commands.get(1))) {
-                                replicationManager.processAck(clientSocket, Long.parseLong(commands.get(2)));
-                                continue; // ACK는 응답 없음
+                        if (commands.isEmpty()) {
+                            continue;
+                        }
+
+                        String command = commands.get(0).toUpperCase();
+
+                        if (inTransaction) {
+                            switch (command) {
+                                case "MULTI":
+                                    sendResponse(outputStream, RespProtocol.createErrorResponse("MULTI calls can not be nested"));
+                                    break;
+                                case "EXEC":
+                                    inTransaction = false;
+                                    List<String> responses = new ArrayList<>();
+                                    for (List<String> queuedCommand : transactionQueue) {
+                                        String response = commandProcessor.processCommand(queuedCommand.get(0), queuedCommand);
+                                        responses.add(response);
+                                        
+                                        // 쓰기 명령 전파
+                                        List<String> writeCommands = Arrays.asList("SET", "XADD", "INCR");
+                                        if (writeCommands.contains(queuedCommand.get(0).toUpperCase())) {
+                                            replicationManager.propagateCommand(queuedCommand);
+                                        }
+                                    }
+                                    transactionQueue.clear();
+                                    sendResponse(outputStream, RespProtocol.createRespArrayFromRaw(responses));
+                                    break;
+                                case "DISCARD":
+                                    inTransaction = false;
+                                    transactionQueue.clear();
+                                    sendResponse(outputStream, RespProtocol.OK_RESPONSE);
+                                    break;
+                                default:
+                                    transactionQueue.add(commands);
+                                    sendResponse(outputStream, RespProtocol.QUEUED_RESPONSE);
+                                    break;
                             }
-                            
-                            String response = commandProcessor.processCommand(command, commands);
-                            sendResponse(outputStream, response);
-                            System.out.println("Sent to " + clientAddress + ": " + response.trim());
-                            
-                            // PSYNC에 대한 특별 처리: RDB 파일 전송 및 레플리카 등록
-                            if (command.equals("PSYNC") && response.startsWith("+FULLRESYNC")) {
-                                byte[] rdbFileBytes = RespProtocol.EMPTY_RDB_BYTES;
-                                String rdbFilePrefix = "$" + rdbFileBytes.length + "\r\n";
-                                
-                                outputStream.write(rdbFilePrefix.getBytes());
-                                outputStream.write(rdbFileBytes);
-                                outputStream.flush();
-                                System.out.println("Sent empty RDB file to " + clientAddress);
-                                
-                                // 이 클라이언트를 레플리카로 등록
-                                replicationManager.addReplica(clientSocket);
-                            }
-                            
-                            // 쓰기 명령어를 레플리카에 전파
-                            List<String> writeCommands = Arrays.asList("SET", "XADD", "INCR");
-                            if (writeCommands.contains(command)) {
-                                replicationManager.propagateCommand(commands);
+                        } else {
+                            switch (command) {
+                                case "MULTI":
+                                    inTransaction = true;
+                                    transactionQueue.clear();
+                                    sendResponse(outputStream, RespProtocol.OK_RESPONSE);
+                                    break;
+                                case "EXEC":
+                                    sendResponse(outputStream, RespProtocol.createErrorResponse("EXEC without MULTI"));
+                                    break;
+                                case "DISCARD":
+                                    sendResponse(outputStream, RespProtocol.createErrorResponse("DISCARD without MULTI"));
+                                    break;
+                                default:
+                                    // 기존 명령어 처리 로직
+                                    // 레플리카로부터의 ACK 처리
+                                    if (command.equals("REPLCONF") && commands.size() >= 3 && "ACK".equalsIgnoreCase(commands.get(1))) {
+                                        replicationManager.processAck(clientSocket, Long.parseLong(commands.get(2)));
+                                        continue; // ACK는 응답 없음
+                                    }
+
+                                    String response = commandProcessor.processCommand(command, commands);
+                                    sendResponse(outputStream, response);
+                                    System.out.println("Sent to " + clientAddress + ": " + response.trim());
+
+                                    // PSYNC에 대한 특별 처리: RDB 파일 전송 및 레플리카 등록
+                                    if (command.equals("PSYNC") && response.startsWith("+FULLRESYNC")) {
+                                        byte[] rdbFileBytes = RespProtocol.EMPTY_RDB_BYTES;
+                                        String rdbFilePrefix = "$" + rdbFileBytes.length + "\r\n";
+
+                                        outputStream.write(rdbFilePrefix.getBytes());
+                                        outputStream.write(rdbFileBytes);
+                                        outputStream.flush();
+                                        System.out.println("Sent empty RDB file to " + clientAddress);
+
+                                        // 이 클라이언트를 레플리카로 등록
+                                        replicationManager.addReplica(clientSocket);
+                                    }
+
+                                    // 쓰기 명령어를 레플리카에 전파
+                                    List<String> writeCommands = Arrays.asList("SET", "XADD", "INCR");
+                                    if (writeCommands.contains(command)) {
+                                        replicationManager.propagateCommand(commands);
+                                    }
+                                    break;
                             }
                         }
                     } else if (line.equals("PING")) {


### PR DESCRIPTION
📌 개요
- Stage 48: MULTI 명령어를 구현하여 트랜잭션 기능을 지원합니다.

🎯 변경사항
- `RedisServer`: 클라이언트별 트랜잭션 상태(`inTransaction`, `transactionQueue`)를 관리하는 로직을 추가했습니다.
- `RespProtocol`: `QUEUED` 응답 및 `EXEC`를 위한 원시 응답 배열 생성 메서드(`createRespArrayFromRaw`)를 추가했습니다.
- `handleClient`: `MULTI`, `EXEC`, `DISCARD` 명령어를 상태에 따라 처리하도록 분기 로직을 구현했습니다.

✅ 구현 세부사항
- `MULTI` 수신 시 트랜잭션 모드로 전환하고, 이후의 명령어들을 큐에 저장합니다.
- `EXEC` 수신 시 큐에 저장된 모든 명령어를 순차적으로 실행하고, 각 명령어의 응답을 배열 형태로 반환합니다.
- `DISCARD` 수신 시 트랜잭션을 중단하고 큐를 비웁니다.
- 트랜잭션 중이 아닐 때 `EXEC` 또는 `DISCARD`를 호출하거나, 트랜잭션 중에 `MULTI`를 중첩 호출하는 경우 에러를 반환합니다.

🧪 테스트 결과
- CodeCrafters의 Stage 48 테스트를 통과했습니다.
- Stage 49부터 53까지의 트랜잭션 관련 테스트 케이스도 미리 구현하여 통과함을 확인했습니다.

📝 추가 정보
- Stage 48 요구사항을 만족할 뿐만 아니라, 향후 트랜잭션 관련 스테이지(49-53)를 대비한 확장성 있는 코드를 작성했습니다.

Closes #52
